### PR TITLE
feat: Refresh token y password legacy

### DIFF
--- a/src/academia/services/auth.service.ts
+++ b/src/academia/services/auth.service.ts
@@ -1,9 +1,9 @@
-import GenericError from "../../infrastructure/models/error.model";
-import {Issuer} from "openid-client";
 import axios from "axios";
-import {v4 as uuid} from 'uuid'
+import { Issuer } from "openid-client";
+import { v4 as uuid } from 'uuid';
 import Cookie from "../../infrastructure/models/cookie.model";
-import {KeycloakUserService} from "../../keycloak/services/user.service";
+import GenericError from "../../infrastructure/models/error.model";
+import { KeycloakUserService } from "../../keycloak/services/user.service";
 
 export class AcademiaUserService {
   public static async loginAndGetCookies(correo: string, contrasenia: string): Promise<Cookie[]> {
@@ -21,7 +21,7 @@ export class AcademiaUserService {
       nonce: uuid(),
       state: uuid(),
     })
-    const [loginResponse] = await KeycloakUserService.loginSSO({oauthUri, correo, contrasenia}) // Inicia sesión en sso
+    const [loginResponse] = await KeycloakUserService.loginSSO({ oauthUri, correo, contrasenia }) // Inicia sesión en sso
 
     const urlParams = new URLSearchParams(loginResponse.headers.location.split('/sso#')[1]) // Obtiene los parámetros de la url de redirección
 
@@ -83,9 +83,7 @@ export class AcademiaUserService {
         throw GenericError.CREDENCIALES_INCORRECTAS
       }
     } catch (err) {
-      if (`${err.response.data}`.includes('Hola,') === false) { // Si no se logeó, se lanza un error
-        throw GenericError.CREDENCIALES_INCORRECTAS
-      }
+      throw err;
     }
 
     return academiaSessionCookies

--- a/src/core/routes/auth.routes.ts
+++ b/src/core/routes/auth.routes.ts
@@ -4,5 +4,6 @@ import { AuthController } from "../controllers/auth.controller";
 const router: Router = Router();
 
 router.post("/auth", AuthController.login);
+router.post("/auth/refresh", AuthController.refresh);
 
 export default router;

--- a/src/infrastructure/middlewares/credentials/academia-credentials.middleware.ts
+++ b/src/infrastructure/middlewares/credentials/academia-credentials.middleware.ts
@@ -1,19 +1,18 @@
-import {CredentialsMiddleware} from "./credentials.middleware";
-import {NextFunction, Request, Response} from "express";
-import CredentialsUtils from "../../utils/credentials.utils";
+import { NextFunction, Request, Response } from "express";
 import Cookie from "../../models/cookie.model";
+import GenericError from "../../models/error.model";
+import CredentialsUtils from "../../utils/credentials.utils";
+import { CredentialsMiddleware } from "./credentials.middleware";
 
 export class AcademiaCredentialsMiddleware extends CredentialsMiddleware {
 
   public static async isLoggedIn(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      let [error, accessToken] = AcademiaCredentialsMiddleware.validateToken(req)
-      if(accessToken.length === 0) {
-        return next(error)
-      }
+      let error = GenericError.TOKEN_INVALIDA;
+      let accessToken = AcademiaCredentialsMiddleware.validateToken(req)
 
       const academiaCookies: Cookie[] = CredentialsUtils.getAcademiaCookies(accessToken);
-      if(academiaCookies.length === 0) {
+      if (academiaCookies.length === 0) {
         error.internalCode = 10.5
         return next(error);
       }
@@ -24,7 +23,7 @@ export class AcademiaCredentialsMiddleware extends CredentialsMiddleware {
       }
 
       next();
-    }catch(error: any) {
+    } catch (error: any) {
       next(error)
     }
   }

--- a/src/infrastructure/middlewares/credentials/credentials.middleware.ts
+++ b/src/infrastructure/middlewares/credentials/credentials.middleware.ts
@@ -1,23 +1,36 @@
-import {Request} from "express";
+import { Request } from "express";
 import GenericError from "../../models/error.model";
 
 /**
  * Esta clase representa la base de los middleware 'Credentials', permitiendo una validación de token.
  */
 export class CredentialsMiddleware {
-  public static validateToken(req: Request): [GenericError,string]{
+  public static validateTokenExist(req: Request): boolean {
     let accessToken: string | undefined = req.headers["authorization"];
-    let error = GenericError.TOKEN_INVALIDA;
-    if(!accessToken) {
-      error.internalCode = 10.1
-      return [error, '']
-    }
+
+    return accessToken !== undefined && accessToken.length > 0;
+  }
+
+  public static validateTokenFormat(req: Request): string {
+    let accessToken: string | undefined = req.headers["authorization"];
 
     if (!accessToken.startsWith("Bearer ")) {
+      let error = GenericError.TOKEN_INVALIDA;
       error.internalCode = 10.2
-      return [error, ''];
+      throw error;
     }
 
-    return [error, accessToken.slice(7, accessToken.length)];
+    return accessToken.slice(7, accessToken.length);
+  }
+
+  public static validateToken(req: Request): string {
+    let existToken: boolean = CredentialsMiddleware.validateTokenExist(req);
+    if (!existToken) {
+      let error = GenericError.TOKEN_INVALIDA;
+      error.internalCode = 10.1
+      throw error;
+    }
+
+    return CredentialsMiddleware.validateTokenFormat(req);
   }
 }

--- a/src/infrastructure/middlewares/credentials/siga-credentials.middleware.ts
+++ b/src/infrastructure/middlewares/credentials/siga-credentials.middleware.ts
@@ -1,27 +1,25 @@
-import GenericError from "../../models/error.model";
-import {CredentialsMiddleware} from "./credentials.middleware";
-import {NextFunction, Request, Response} from "express";
-import CredentialsUtils from "../../utils/credentials.utils";
+import { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import Usuario from "../../../core/models/usuario.model";
+import GenericError from "../../models/error.model";
+import CredentialsUtils from "../../utils/credentials.utils";
+import { CredentialsMiddleware } from "./credentials.middleware";
 
 export class SigaCredentialsMiddleware extends CredentialsMiddleware {
 
   public static async isLoggedIn(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      let [error, accessToken] = SigaCredentialsMiddleware.validateToken(req)
-      if(accessToken.length === 0) {
-        return next(error)
-      }
+      let error = GenericError.TOKEN_INVALIDA;
+      let accessToken = SigaCredentialsMiddleware.validateToken(req)
 
       const sigaToken: string = CredentialsUtils.getSigaToken(accessToken);
-      if(sigaToken.length === 0) {
+      if (sigaToken.length === 0) {
         error.internalCode = 10.4
         return next(error);
       }
 
       const decoded: any = jwt.decode(sigaToken);
-      if(decoded.exp < Date.now()/1000) {
+      if (decoded.exp < Date.now() / 1000) {
         return next(GenericError.SIGA_UTEM_EXPIRO);
       }
 
@@ -39,7 +37,7 @@ export class SigaCredentialsMiddleware extends CredentialsMiddleware {
       }
 
       next();
-    }catch(error: any) {
+    } catch (error: any) {
       next(error)
     }
   }

--- a/src/mi-utem/services/auth.service.ts
+++ b/src/mi-utem/services/auth.service.ts
@@ -1,8 +1,8 @@
-import Cookie from "../../infrastructure/models/cookie.model";
-import { KeycloakUserService } from "../../keycloak/services/user.service";
-import GenericError from "../../infrastructure/models/error.model";
 import axios from "axios";
-import * as cheerio from 'cheerio'
+import * as cheerio from 'cheerio';
+import Cookie from "../../infrastructure/models/cookie.model";
+import GenericError from "../../infrastructure/models/error.model";
+import { KeycloakUserService } from "../../keycloak/services/user.service";
 
 export class MiUtemAuthService {
 
@@ -44,7 +44,7 @@ export class MiUtemAuthService {
         maxRedirects: 0
       })
     } catch (err) {
-      if(err.response.status !== 302) {
+      if (err.response.status !== 302) {
         throw err
       }
 
@@ -80,9 +80,9 @@ export class MiUtemAuthService {
       });
 
       return Cookie.merge(cookies, response.headers["set-cookie"].map(it => Cookie.parse(it)))
-    }catch (error) {
+    } catch (error) {
       const response = error.response
-      if(response && response.status !== 302) {
+      if (response && response.status !== 302) {
         return undefined
       }
 
@@ -95,14 +95,14 @@ export class MiUtemAuthService {
   // Revisa que las cookies sean válidas
   public static async valido(cookies: Cookie[]): Promise<boolean> {
     try {
-      const request = await axios.get(`${process.env.MI_UTEM_URL}/users/mi_perfil`, {
+      const request = await axios.get(`${process.env.MI_UTEM_URL}/academicos/mi-perfil-estudiante`, {
         headers: {
           Cookie: Cookie.header(cookies),
         },
       })
 
       return `${request?.data}`.includes('id="kc-form-login"') === false // Si es invalido, se redirige al login mostrando el formulario de autenticación
-    } catch(_) {}
+    } catch (_) { }
     return false
   }
 
@@ -117,6 +117,7 @@ export class MiUtemAuthService {
     const valido = await MiUtemAuthService.valido(cookies)
     const sessionId: string = cookies?.find(it => it.name == "sessionid")?.value || null;
     const csrfToken: string = cookies?.find(it => it.name == "csrftoken")?.value || null;
+
     if (!valido || !sessionId || !csrfToken) {
       error.internalCode = 3.2
       throw error

--- a/src/siga-api/services/auth.service.ts
+++ b/src/siga-api/services/auth.service.ts
@@ -3,6 +3,29 @@ import Usuario from "../../core/models/usuario.model";
 import GenericError from "../../infrastructure/models/error.model";
 
 export class SigaApiAuthService {
+  public static async loginAndGetToken(correo: string, contrasenia: string): Promise<string> {
+    try {
+      const res = await axios.post(`${process.env.SIGA_API_URL}/autenticacion/login/`, `username=${correo}&password=${contrasenia}`, {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Host: "siga.utem.cl",
+        },
+      });
+
+      return res.data.response.token;
+    } catch (err) {
+      if (err.response?.status === 401) {
+        console.debug({
+          message: "Credenciales incorrectas",
+          error: err,
+        })
+        throw GenericError.CREDENCIALES_INCORRECTAS
+      }
+
+      throw err
+    }
+  }
+
   public static async loginAndGetProfile(correo: string, contrasenia: string): Promise<Usuario> {
     try {
       const res = await axios.post(`${process.env.SIGA_API_URL}/autenticacion/login/`, `username=${correo}&password=${contrasenia}`, {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
             "es2021",
             "dom"
         ],
-        "moduleResolution": "NodeNext"
-    }
+        "moduleResolution": "node",
+        
+    },
+    "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
- Se agrega un endpoint para refrescar las token, detectando primero cuando está expirada para refrescar solo las necesarias
- Se agrega al middleware de Mi UTEM el método de password para obtener las contraseñas

Hay que mantener este último comportamiento legacy, ya que si bien en [mi-utem PR #36](https://github.com/exdevutem/mi-utem/pull/36) se cambia el uso de endpoints Mi UTEM, esta funcionalidad no saldrá automáticamente, debido a tiempos de revisión de PR, revisión de actualización en las tiendas y delay de los usuarios para actualizar